### PR TITLE
Bucklescript v8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 [![LICENSE](https://img.shields.io/github/license/ambientlight/reductive-dev-tools)](https://github.com/ambientlight/reductive-dev-tools/blob/master/LICENSE)
 [![ISSUES](https://img.shields.io/github/issues/ambientlight/reductive-dev-tools)](https://github.com/ambientlight/reductive-dev-tools/issues)
 
-[reductive](https://github.com/reasonml-community/reductive) and [reason-react](https://github.com/reasonml/reason-react) reducer component integration with [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension)
+[reductive](https://github.com/reasonml-community/reductive) and [reason-react](https://github.com/reasonml/reason-react) reducer component integration with [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension).
+
+Requires **bucklescript 8.x.x**, for lower versions of bucklescript, please rely on **2.0.0**.
+
 
 ![image](assets/demo.gif)
 
@@ -74,7 +77,7 @@ And refer to [old documentation](https://github.com/ambientlight/reductive-dev-t
 ## Serialization
 
 ### Actions
-[redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension) uses value under `type` key of action object for its name in the monitor. Most likely you are going to use [variants](https://reasonml.github.io/docs/en/variant) for actions, which need to be serialized into js objects to be usefully displayed inside the extension. Actions serialization is built-in. As an alternative, you can override default serializer by passing `~actionSerializer` like:
+With bucklescript 8 release, variants are js-objects at runtime, so this extension no longer serializes actions. By default it only extracts variant name from `Symbol(name)` when `-bs-g` flag is set in `bsconfig.json`.  If needed, you can define your custom serialization by passing `~actionSerializer` like:
 
 ```reason
 ReductiveDevTools.Connectors.enhancer(
@@ -98,8 +101,6 @@ There are few caveats that apply to default serialization though.
 
 1. Make sure to add `-bs-g` into `"bsc-flags"` of your **bsconfig.json** to have variant names available.
 2. Variants with constructors should be prefered to plain (`SomeAction(unit)` to `SomeAction`) since plain varaints do no carry debug metedata(in symbols) with them (represented as numbers in js).
-3. Action names won't be displayed when using [extensible variants](https://caml.inria.fr/pub/docs/manual-ocaml/manual037.html#sec269), they also do not carry debug metadata. [Extensible variant name becomes "update"](https://github.com/ambientlight/reductive-dev-tools/issues/2)
-4. Records inside variants do not carry debug metadata in bucklescript yet, if needed you can tag them manually. See [Additional Tagging](#additional-tagging).
 
 ### State
 
@@ -162,39 +163,3 @@ ReductiveDevTools.Extension.enhancerOptions(
   ~traceLimit=50
   ())
 ```
-
-## Additional Tagging
-You can also manually customize serialized objects keys and action names displayed inside extension.
-Two common usecases:
-
-1. Labeling variants with constructors.
-
-	```reason
-	type routerActions = [
-	  | `RouterLocationChanged(list(string), string, string)
-	];
-	
-	open ReductiveDevTools.Utilities;
-	Reductive.Store.dispatch(store, 
-	  `RouterLocationChanged(url.path, url.hash, url.search)
-	    |. labelVariant([|"path", "hash", "search"|]));
-	```
-2. Labeling record keys for records inside variants (since Records inside variants do not carry debug metadata in bucklescript yet).
-
-	```reason
-	type url = {
-	  path: list(string),
-	  hash: string,
-	  search: string,
-	};
-	type routerActions = [
-	  | `RouterLocationChanged(url)
-	];
-	
-	open ReductiveDevTools.Utilities;
-	Reductive.Store.dispatch(store, 
-	  `RouterLocationChanged(url
-	    |. tagRecord([|"path", "hash", "search"|]));
-	```
-	
-This can also be used to override bucklescript debug metadata(if really needed). Definitions are at: [utilities.rei](https://github.com/ambientlight/reductive-dev-tools/blob/a530ea6d09d7facad2b70c061703eff52cfa80b4/src/utilities.rei#L63-L67)

--- a/src/utilities.re
+++ b/src/utilities.re
@@ -1,15 +1,3 @@
-/**
- * Substitute for Belt.Option.getExn
- * that raises custom exception if option contains no value
- */
-let unwrap = (opt: option('a), exc: exn) => switch(opt){ 
-  | Some(value) => value
-  | None => raise(exc)
-};
-
-[@bs.val] [@bs.scope "JSON"]
-external parse: string => Js.Json.t = "parse";
-
 module Symbol {
   type t = Js.t({.});
 
@@ -25,6 +13,9 @@ module Symbol {
     value: value,
     writable: false
   }]);
+
+  [@bs.send]
+  external toString: t => string = "toString";
 };
 
 module Object {
@@ -38,25 +29,21 @@ module Object {
 };
 
 module Serializer {
-  module Exceptions {
-    exception UnexpectedSerializedVariantKey(string);
-    exception PolyVarTagNotPresentWhileExpected(string);
-    exception UnexpectedActionType(string);
-  };
-
   module DebugSymbol {
     [@bs.deriving jsConverter]
     type t = [
-      | [@bs.as "Symbol(BsVariant)"] `BsVariant
-      | [@bs.as "Symbol(BsPolyVar)"] `BsPolyVar
-      | [@bs.as "Symbol(BsRecord)"] `BsRecord
-      | [@bs.as "Symbol(ReductiveDevToolsBsLabeledVariant)"] `DevToolsBsLabeledVariant
+      // legacy pre-bs8 symbols
+      // | [@bs.as "Symbol(BsVariant)"] `BsVariant
+      // | [@bs.as "Symbol(BsPolyVar)"] `BsPolyVar
+      // | [@bs.as "Symbol(BsRecord)"] `BsRecord
+      // | [@bs.as "Symbol(ReductiveDevToolsBsLabeledVariant)"] `DevToolsBsLabeledVariant
+      | [@bs.as "Symbol(name)"] `Name
     ];
 
     let ofReasonAction = action => {
       let symbols = Object.getOwnPropertySymbols(action);
       let extractedSymbols = symbols
-        |> Array.mapi((idx, symbol) => (idx, {j|$symbol|j}));
+        |> Array.mapi((idx, symbol) => (idx, symbol |. Symbol.toString));
 
       /** 
        * make sure Bs* symbols always appearing before ReductiveDevTool ones 
@@ -82,358 +69,32 @@ module Serializer {
   };
 
   module Action {
-    let viewAsDict: 'a => Js.Dict.t('b) = action => Obj.magic(action); 
-    let viewAsArray: 'a => array('b) = action => Obj.magic(action);
-    let viewAsList: 'a => list('b) = action => Obj.magic(action);
-    let viewAsOpenObject: 'a => Js.t({..}) = action => Obj.magic(action);
-
-    module Type {
-      [@bs.deriving jsConverter]
-      type t = [
-        /* next three require -bs-g specified */
-        | `VariantC
-        | `PolyVarC
-        | `Record
-        /* variants without constructors and everything else belong here */
-        | `Raw
-      ];
-
-      let fromReasonAction: 'a => t = action => 
-        switch(Belt.Array.get(DebugSymbol.ofReasonAction(action), 0)){
-        | Some((_, `BsVariant)) => `VariantC
-        | Some((_, `BsPolyVar)) => `PolyVarC
-        | Some((_, `BsRecord)) when Js.Array.isArray(action) => `Record
-        | _ => `Raw
-        }
-    };
-
-    /**
-     * additional metadata that can be passed with variant actions 
-     * to customize keys and action name
-     */
-    module UserMeta {
-      [@bs.deriving abstract]
-      type t = {
-        [@bs.optional] keys: array(string),
-        [@bs.optional] actionName: string
-      };
-
-      let fromReasonAction: 'a => option(t) = action => DebugSymbol.symbolValue(action, `DevToolsBsLabeledVariant)
-    };
-
-    module Internals {
-      [@bs.deriving abstract]
-      type t('a) = {
-        kind: string,
-
-        [@bs.optional] rawValue: 'a,
-        [@bs.optional] polyVarTag: int,
-        /* runtime representation of regular variants with more then one constructor contains tag */
-        [@bs.optional] tag: int,
-        [@bs.optional] userMeta: UserMeta.t,
-        [@bs.optional] recordKeys: array(string),
-
-        /* utilized on object serialization */
-        [@bs.optional] isList: bool
-      };
-
-      let fromReasonAction = action => {
-        let actionType = Type.fromReasonAction(action); 
-        let userMeta = UserMeta.fromReasonAction(action);
-        switch(actionType){
-        | `Raw => 
-          t(~kind=Type.tToJs(actionType),
-            ~rawValue=action,
-            ~userMeta?,
-            ())
-        | `Record => 
-          t(~kind=Type.tToJs(actionType),
-            ~recordKeys=?DebugSymbol.symbolValue(action, `BsRecord),
-            ())
-        | `VariantC => 
-          t(~kind=Type.tToJs(actionType),
-            ~tag=?Js.Dict.get(viewAsDict(action), "tag"),
-            ~userMeta?,
-            ())
-        | `PolyVarC => 
-          t(~kind=Type.tToJs(actionType),
-            ~tag=?Js.Dict.get(viewAsDict(action), "tag"),
-            ~polyVarTag=?Belt.Array.get(viewAsArray(action), 0),
-            ~userMeta?,
-            ())
-        };
-      }
-    };
-
-    type t('a, 'b) = Js.t({
+   
+    type t('a) = Js.t({
       ..
       /*
        * denotes the action name displayed in the monitor 
        * for an actual action 'type', please check Internals.t._type
        */
-      _type: string,
-      __internal: Internals.t('b)
+      _type: string
     }) as 'a;
 
-    let _actionName = (action, internals) => {
-      let userMetaName = internals
-        |. Internals.userMetaGet
-        |. Belt.Option.flatMap(userMeta => userMeta|.UserMeta.actionNameGet);
-      let actionType = Type.fromReasonAction(action);
-      switch((userMetaName, actionType)){
-      | (Some(userMetaName), _) => userMetaName
-      | (_, `VariantC) => Belt.Option.getWithDefault(DebugSymbol.symbolValue(action, `BsVariant), "update")
-      | (_, `PolyVarC) => Belt.Option.getWithDefault(DebugSymbol.symbolValue(action, `BsPolyVar), "update")
-      | _ => "update" 
-      }
-    };
-
-    let rec serializeObject = (obj: 'a) => {
-      let isList = DebugSymbol.symbolValue(obj, `BsVariant)
-      |. Belt.Option.map(variantName => variantName == "::")
-      let recordKeys = DebugSymbol.symbolValue(obj, `BsRecord)
-      let base = [%bs.obj { 
-        __internal: Internals.t(
-          ~kind=Type.tToJs(`Raw),
-          ~recordKeys?, 
-          ~isList?,
-          ())
-      }];
-
-      let serialized = 
-        switch(Js.Types.classify(obj), Type.fromReasonAction(obj)){
-        | (JSObject(obj), `Record) =>
-          _serializeRecordToDict(~obj=Obj.magic(obj))
-        | (JSObject(obj), _) when Js.Array.isArray(obj) => { 
-          let array = Belt.Option.getWithDefault(isList, false) ? Array.of_list(viewAsList(obj)) : viewAsArray(obj);
-          Array.map(entity => serializeObject(entity), array) |> viewAsDict
-        }
-        | (JSObject(obj), _) when !Js.Array.isArray(obj) => {
-          let dict: Js.Dict.t('a) = viewAsDict(obj);
-          Js.Dict.map((. entity) => serializeObject(entity), dict)
-        }
-        | _ => Obj.magic(obj)
-        };
-
-      switch(Js.Types.classify(serialized)){
-      | JSObject(serialized) => Js.Obj.assign(base, viewAsOpenObject(serialized))
-      | _ => viewAsOpenObject(serialized)
-      };
     
-    } and _serializeRecordToDict = (~obj: 'a) => {
-      let keys = DebugSymbol.symbolValue(obj, `BsRecord);
-      switch(keys){
-      | None => 
-        /* turns array into object with serialization applied to each value */
-        Js.Obj.assign(
-          Js.Obj.empty(),
-          Array.map(entity => serializeObject(entity), viewAsArray(obj)) |> viewAsOpenObject
-        ) |> viewAsDict
-      | Some(keys) =>
-        Belt.Array.reduceWithIndex(
-          viewAsArray(obj),
-          Js.Dict.empty(),
-          (target, value, idx) => {
-            let key = Belt.Array.get(keys, idx);
-            Js.Dict.set(
-              target,
-              Belt.Option.getWithDefault(key, string_of_int(idx)),
-              serializeObject(value)
-            );
-            target
-          })
-      }
-    };
-
-    let _serializeVariantToDict = (~action: 'a, ~isPolyVar: bool) => {
-      let keys = DebugSymbol.symbolValue(action, `DevToolsBsLabeledVariant)
-        |. Belt.Option.flatMap(meta => meta|.UserMeta.keysGet);
-      switch(keys){
-      | None => 
-        Js.Obj.assign(
-          Js.Obj.empty(), 
-          Array.map(entity => serializeObject(entity), viewAsArray(action)) |> viewAsOpenObject
-        )
-      | Some(keys) => {
-        Belt.Array.reduceWithIndex(
-          isPolyVar ? viewAsArray(Obj.magic(action)[1]) : viewAsArray(action),
-          Js.Dict.empty(),
-          (target, value, idx) => {
-            let variantKey = Belt.Array.get(keys, idx);
-            Js.Dict.set(
-              target,
-              Belt.Option.getWithDefault(variantKey, string_of_int(idx)),
-              serializeObject(value)
-            );
-            target
-          }
-        ) |> viewAsOpenObject
-      }}
-    };
-
-    let rec deserializeObject = (~obj: Js.t({.. __internal: Js.Undefined.t(Internals.t('a))})) => {
-      let isList = obj##__internal
-        |. Js.Undefined.toOption
-        |. Belt.Option.flatMap(Internals.isListGet)
-        |. Belt.Option.getWithDefault(false);
-      let recordKeys = obj##__internal
-        |. Js.Undefined.toOption
-        |. Belt.Option.flatMap(Internals.recordKeysGet);
-
-      switch((Js.Types.classify(obj), recordKeys)){
-      | (JSObject(_objectValue), Some(_recordKeys)) => _deserializeRecord(~obj) |> Obj.magic
-      | (JSObject(objectValue), _) => {
-        let deserialized = Js.Dict.keys(viewAsDict(objectValue))
-          |. Belt.Array.keep(key => key != "__internal")
-          |> Array.map(key => deserializeObject(~obj=Js.Dict.unsafeGet(viewAsDict(objectValue), key)));
-        let deserialized = (isList ? viewAsArray(Array.to_list(deserialized)) : deserialized) |> Obj.magic;
-        if(isList){
-          Symbol.setValue(deserialized, Symbol.create("BsVariant"), "::");
-        };
-        
-        deserialized
-      }
-      | _ => Obj.magic(obj)
-      };
-      
-    } and _deserializeRecord = (~obj: Js.t({.. __internal: Js.Undefined.t(Internals.t('a))})) => {
-      let recordKeys = obj##__internal
-        |. Js.Undefined.toOption
-        |. Belt.Option.flatMap(Internals.recordKeysGet);
-
-      let deserialized = Js.Dict.keys(viewAsDict(obj))
-        |. Belt.Array.keep(key => key != "__internal")
-        |> Array.map(key => deserializeObject(~obj=Js.Dict.unsafeGet(viewAsDict(obj), key)));
-
-      switch(recordKeys){
-      | Some(recordKeys) => Symbol.setValue(deserialized, Symbol.create("BsRecord"), recordKeys) 
-      | None => ()
-      };
-
-      deserialized
-    };
-
-    let _deserializeVariant = (~action: t('b, 'action), ~actionType: Type.t) => {
-      let internal = action##__internal;
-      let keys = internal
-        |. Internals.userMetaGet
-        |. Belt.Option.flatMap(userMeta => userMeta|.UserMeta.keysGet);
-      let varTag = internal |.Internals.tagGet;
-      let polyVarTag = internal
-        |. Internals.polyVarTagGet;
-      let deserialized = 
-        switch(keys){
-        | None => 
-          Js.Dict.keys(viewAsDict(action))
-            |. Belt.Array.keep(key => key != "__internal" && key != "type")
-            |> Array.map(key => deserializeObject(~obj=Js.Dict.unsafeGet(viewAsDict(action), key)))
-        | Some(keys) =>
-          Js.Dict.keys(viewAsDict(action))
-            |. Belt.Array.keep(key => key != "__internal" && key != "type")
-            |> Array.fold_left((deserialized, key) => {
-              let idx = Js.Array.findIndex(entity => entity == key, keys);
-              if(idx == -1){
-                raise(Exceptions.UnexpectedSerializedVariantKey({j|Serialized variant key($key) corresponding array idx has not been found.|j}))
-              } else {
-                deserialized[idx] = Js.Dict.unsafeGet(viewAsDict(action), key)
-              };
-
-              deserialized
-            }, Belt.Array.makeUninitializedUnsafe(Array.length(keys)));
-        };
-
-      let actionTypeStr = Type.tToJs(actionType);
-      switch(actionType){
-      | `PolyVarC => {
-        let polyVarTag = polyVarTag |. unwrap(Exceptions.PolyVarTagNotPresentWhileExpected("PolyVar tag not present while expected"));
-        let deserialized = switch(keys){
-        | None => {
-          deserialized[0] = Obj.magic(polyVarTag);
-          deserialized
-        }
-        | Some(_) => { 
-          let deserialized = [|Obj.magic(polyVarTag), Obj.magic(deserialized)|];
-          Symbol.setValue(deserialized, Symbol.create("ReductiveDevToolsBsLabeledVariant"), internal|.Internals.userMetaGet);
-          deserialized
-        }};
-
-        Symbol.setValue(deserialized, Symbol.create("BsPolyVar"), action##_type);
-        deserialized
-      }
-      | `VariantC => {
-        Symbol.setValue(deserialized, Symbol.create("BsVariant"), action##_type);
-        switch(varTag){
-        | None => deserialized
-        | Some(varTag) => {
-          Js.Dict.set(viewAsDict(deserialized), "tag", varTag);
-          deserialized
-        }}
-      }
-      | _ => raise(Exceptions.UnexpectedActionType({j|$(actionTypeStr)|j}))
-      }
+    let fromReasonAction: 'action => t({. "_type": string}) = action => {
+      DebugSymbol.symbolValue(action, `Name)
+      |. Belt.Option.map(actionName => {
+        let base = [%bs.obj {_type: actionName }];
+        Js.Obj.assign(base, Obj.magic(action))
+      })
+      |. Belt.Option.getWithDefault(Obj.magic(action))
     }
 
-    let fromReasonAction: 'action => t('b, 'action) = action => {
-      let internal = Internals.fromReasonAction(action);
-      let actionName = _actionName(action, internal);
-      let base = [%bs.obj {_type: actionName, __internal: internal}];
-
-      switch(Type.fromReasonAction(action)){
-      | `Raw => base
-      | `Record => Js.Obj.assign(base, _serializeRecordToDict(~obj=action) |> viewAsOpenObject)
-      | `VariantC => Js.Obj.assign(base, _serializeVariantToDict(~action, ~isPolyVar=false))
-      | `PolyVarC => Js.Obj.assign(base, _serializeVariantToDict(~action, ~isPolyVar=true))
-      }
-    }
-
-    let toReasonAction = (action: t('b, 'action)) => {
-      let internal = action##__internal;
-      let actionType = internal
-        |. Internals.kindGet 
-        |> Type.tFromJs
-        |. Belt.Option.getWithDefault(`Raw);
-
-      switch(actionType){
-      | `Raw => internal|.Internals.rawValueGet|.Belt.Option.getExn
-      | `Record => _deserializeRecord(~obj=Obj.magic(action)) |> Obj.magic
-      | `VariantC
-      | `PolyVarC => _deserializeVariant(~action, ~actionType) |> Obj.magic
-      };
+    let toReasonAction = (action: t('s)) => {
+      // not errasing a type field here,, if needed, use a customSerializer
+      Obj.magic(action)
     }
   };
 
   let serializeAction = action => Action.fromReasonAction(action);
-  let serializeObject = obj => Action.serializeObject(obj);
-
   let deserializeAction = action => Action.toReasonAction(action);
-  let deserializeObject = obj => Action.deserializeObject(~obj);
 };
-
-let labelVariant: ('a, array(string)) => 'a = (variant, keys) => {
-  Symbol.setValue(variant, Symbol.create("ReductiveDevToolsBsLabeledVariant"), Serializer.Action.UserMeta.t(
-    ~keys,
-    ()
-  ));
-  variant
-};
-
-let tagVariant: ('a, string) => 'a = (variant, name) => {
-  Symbol.setValue(variant, Symbol.create("BsVariant"), name);
-  variant
-};
-
-let tagList: list('a) => list('a) = list =>
-  switch(Js.Types.classify(list)){
-  | JSObject(_) => tagVariant(list, "::")
-  | _ => list
-  };
-
-let tagPolyVar: ('a, string) => 'a = (polyVar, name) => {
-  Symbol.setValue(polyVar, Symbol.create("BsPolyVar"), name);
-  polyVar
-};
-
-let tagRecord: ('a, array(string)) => 'a = (obj, keys) => {
-  Symbol.setValue(obj, Symbol.create("BsRecord"), keys);
-  obj;
-}

--- a/src/utilities.rei
+++ b/src/utilities.rei
@@ -1,67 +1,38 @@
-let unwrap: (option('a), exn) => 'a;
-let parse: string => Js.Json.t
+module Symbol {
+  type t = Js.t({.});
+
+  let getValue: ('b, t) => 'a;
+  let setValue: ('a, t, 'b) => unit;
+  let toString: t => string;
+};
 
 module Serializer {
+  module DebugSymbol {
+    type t = [
+      // legacy pre-bs8 symbols
+      // | [@bs.as "Symbol(BsVariant)"] `BsVariant
+      // | [@bs.as "Symbol(BsPolyVar)"] `BsPolyVar
+      // | [@bs.as "Symbol(BsRecord)"] `BsRecord
+      // | [@bs.as "Symbol(ReductiveDevToolsBsLabeledVariant)"] `DevToolsBsLabeledVariant
+      | [@bs.as "Symbol(name)"] `Name
+    ];
+
+    let ofReasonAction: 'a => array((int, t));
+    let symbolValue: ('b, t) => option('a)
+  }
+
   module Action {
-    module Type {
-      [@bs.deriving jsConverter]
-      type t = [
-        /* next three require -bs-g specified */
-        | `VariantC
-        | `PolyVarC
-        | `Record
-        /* variants without constructors and everything else belong here */
-        | `Raw
-      ];
-
-      let fromReasonAction: 'a => t;
-    };
-
-    module UserMeta {
-      [@bs.deriving abstract]
-      type t = {
-        [@bs.optional] keys: array(string),
-        [@bs.optional] actionName: string
-      };
-    };
-
-    module Internals {
-      [@bs.deriving abstract]
-      type t('a) = {
-        kind: string,
-
-        [@bs.optional] rawValue: 'a,
-        [@bs.optional] polyVarTag: int,
-        /* runtime representation of regular variants with more then one constructor contains tag */
-        [@bs.optional] tag: int,
-        [@bs.optional] userMeta: UserMeta.t,
-        [@bs.optional] recordKeys: array(string),
-
-        /* utilized on object serialization */
-        [@bs.optional] isList: bool
-      };
-    };
-
-    type t('a, 'b) = Js.t({
+    
+    type t('a) = Js.t({
       ..
       /*
        * denotes the action name displayed in the monitor 
        * for an actual action 'type', please check Internals.t._type
        */
-      _type: string,
-      __internal: Internals.t('b)
+      _type: string
     }) as 'a;
   };
 
-  let serializeAction: 'a => Action.t({. "__internal": Action.Internals.t('a), "_type": string}, 'a);
-  let serializeObject: 'a => Js.t({.. __internal: Js.Undefined.t(Action.Internals.t('a))});
-
-  let deserializeAction: Action.t({. "__internal": Action.Internals.t('a), "_type": string}, 'a) => 'a;
-  let deserializeObject: Js.t({.. __internal: Js.Undefined.t(Action.Internals.t('a))}) => 'b;
+  let serializeAction: 'a => Action.t({. "_type": string});
+  let deserializeAction: Action.t({. "_type": string}) => 'a;
 };
-
-let labelVariant: ('a, array(string)) => 'a; 
-let tagList: list('a) => list('a);
-let tagVariant: ('a, string) => 'a;
-let tagPolyVar: ('a, string) => 'a;
-let tagRecord: ('a, array(string)) => 'a;


### PR DESCRIPTION
* deprecates built-in serialization for actions
* drops all legacy serialization logic from utilities
* since js runtime representation is changed with also debug metadata appearing under different symbol, this release will no longer support bucklescript 7 or less.
* fixes symbol to string runtime exception